### PR TITLE
Add config file 'interface/gdlink.cfg' and modify 'target/gd32vf103.cfg'

### DIFF
--- a/tcl/interface/gdlink.cfg
+++ b/tcl/interface/gdlink.cfg
@@ -1,0 +1,2 @@
+# OpenOCD probe config file for GD-Link
+adapter driver cmsis-dap

--- a/tcl/target/gd32vf103.cfg
+++ b/tcl/target/gd32vf103.cfg
@@ -27,9 +27,5 @@ if { [info exists FLASH_SIZE] } {
 set _FLASHNAME $_CHIPNAME.flash
 
 flash bank $_FLASHNAME gd32vf103 0x08000000 0 0 0 $_TARGETNAME
-riscv set_reset_timeout_sec 1
-init
-
-halt
-
-
+riscv set_reset_timeout_sec 2
+riscv set_command_timeout_sec 2


### PR DESCRIPTION
**About `interface/gdlink.cfg`:**
New users probably don't know that the `GD-Link` is actually a `CMSIS-DAP` probe. Adding this `interface/gdlink.cfg` file makes this explicit, and will certainly help new users.

**About `target/gd32vf103.cfg`:**
In Embeetle, we use the "single-console-approach" to flash firmware. That means we launch GDB in a console and then use GDB to launch OpenOCD in *the same console*. You can read more about this approach here: https://embeetle.com/#embeetle-ide/manual/flash/gdbinit
The `target/gd32vf103.cfg` file in your OpenOCD repo ends with the commands `init` and `halt`. This causes a crash for our single-console-approach:
```
Error: The 'gdb_port' command must be used before 'init'.
```
In my pull request, I suggest to remove these `init` and `halt` commands and replace them with the following:
```
riscv set_reset_timeout_sec 2
riscv set_command_timeout_sec 2
```
Thank you very much ^_^
